### PR TITLE
Karma cannot find the icon with the named web

### DIFF
--- a/src/app/scam/components/shared/nav/nav.component.html
+++ b/src/app/scam/components/shared/nav/nav.component.html
@@ -67,7 +67,7 @@
       i18n-title
       [matMenuTriggerFor]="langMenu"
       mat-icon-button>
-      <mat-icon svgIcon="web"></mat-icon>
+      <mat-icon>language</mat-icon>
     </button>
     <mat-menu #langMenu="matMenu">
       <a href="/de/" mat-menu-item><span class="mr1 flag-icon flag-icon-de"></span>Deutsch</a>


### PR DESCRIPTION
It seems that in fact this icon is named (or was renamed to) 'language'. I have confirmed locally that after this commit there is no change to what a user can see in the Navigation, language icon stays exactly the same and there is no error in the test logs.

https://material.io/resources/icons/?icon=language&style=baseline

Closes https://github.com/deploji/deploji/issues/42

![Screenshot from 2020-09-19 16-20-11](https://user-images.githubusercontent.com/18489094/93670029-58cca100-fa98-11ea-853e-a5770be336b9.png)