### PR TITLE
Ansible job fix

### DIFF
--- a/src/app/core/services/survey-input-manager.service.ts
+++ b/src/app/core/services/survey-input-manager.service.ts
@@ -31,7 +31,7 @@ export class SurveyInputManagerService {
 
     survey.Inputs.forEach((input: SurveyInput, index: number) => {
       if (values[index]) {
-        result += `${input.VariableName}:${values[index]}\n`;
+        result += `${input.VariableName}: ${values[index]}\n`;
       }
     });
 


### PR DESCRIPTION
The ansible job command probably should contain a space between name and value of a given extra variable.