### PR TITLE
Configure proxy for demo.deploji.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "ng lint",
     "e2e": "ng e2e",
     "build-i18n": "for lang in en pl; do ng build --output-path=dist/$lang --aot --prod --base-href /$lang/ ; done",
-    "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points"
+    "postinstall": "ngcc --properties es2015 browser module main --first-only --create-ivy-entry-points",
+    "proxy-serve": "ng serve --proxy-config proxy-serve.conf.json"
   },
   "private": false,
   "dependencies": {

--- a/proxy-serve.conf.json
+++ b/proxy-serve.conf.json
@@ -1,0 +1,7 @@
+{
+  "/api/*": {
+    "target": "https://demo.deploji.com",
+    "secure": false,
+    "changeOrigin": true
+  }
+}


### PR DESCRIPTION
Deploji currently has two proxy configurations, but both proxy to localhost. I've added a file to proxy for demo.deploji.com